### PR TITLE
Removes URL from const and adds into query function

### DIFF
--- a/R/consts.R
+++ b/R/consts.R
@@ -1,6 +1,5 @@
 # Constant urls for data retrieval
 cdec_urls <- list(
-  download_shef = "http://cdec.water.ca.gov/cgi-progs/querySHEF?station_id={STATION}&sensor_num={SENSOR}&dur_code={DURCODE}&start_date={STARTDATE}&end_date={ENDDATE}&data_wish=Download+SHEF+Data+Now",
   wy_forecast = "http://cdec.water.ca.gov/cgi-progs/iodir/wsi",
   station_hydro_area = "http://cdec.water.ca.gov/cgi-progs/staMeta?station_id=STATION",
   station_metadata = "https://cdec.water.ca.gov/cgi-progs/staSearch?sta_chk=on&sta=STATION",

--- a/R/query.R
+++ b/R/query.R
@@ -48,12 +48,12 @@ cdec_query <- function(station, sensor_num, dur_code,
 
   if (is.null(end_date)) {end_date <- Sys.Date() + 1}
 
-  query_url <- glue::glue(cdec_urls$download_shef,
-                          STATION=station,
-                          SENSOR = as.character(sensor_num),
-                          DURCODE = as.character(dur_code),
-                          STARTDATE = as.character(start_date),
-                          ENDDATE = as.character(end_date))
+  query_url <- sprintf("http://cdec.water.ca.gov/cgi-progs/querySHEF?station_id=%s&sensor_num=%s&dur_code=%s&start_date=%s&end_date=%s&data_wish=Download+SHEF+Data+Now",
+                       station,
+                       as.character(sensor_num),
+                       as.character(dur_code),
+                       as.character(start_date),
+                       as.character(end_date))
 
   temp_file <- tempfile(tmpdir = tempdir())
 


### PR DESCRIPTION
Checked that Query still works and formatted URL so no longer called from const. 
As far as I can tell it still makes sense to stick with this approach given cdec returns. 
Closes #55 