### PR TITLE
fixes #68; passes dataset test

### DIFF
--- a/R/datasets.R
+++ b/R/datasets.R
@@ -25,7 +25,7 @@ cdec_datasets <- function(station, keyword=NULL) {
   )
 
   resp_html <- xml2::read_html(resp)
-  resp_at_node <- rvest::html_nodes(resp_html, "div#main_content table")
+  resp_at_node <- rvest::html_elements(resp_html, "section")
 
   # cdec does not return any error code when a faulty query is submitted
   # here I check when the returned response is of length zero instead


### PR DESCRIPTION
website changed; pulling the section instead of the main content table fixes issue #68.  While we were at it we swapped out `html_nodes` (now deprecated) for `html_elements()`.

